### PR TITLE
persisting sessionAttributes for conversation

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,9 +54,7 @@ exports.handler = (event, context, callback) => {
 				  botAlias: process.env.BOT_ALIAS,
 				  botName: process.env.BOT_NAME,
 				  inputText: twilioSMS.Body,
-				  userId: userNumber,
-				  sessionAttributes: {
-				  }
+				  userId: userNumber
 				};
 				lexruntime.postText(params, function(err, data) {
 					var twimlResponse = new twilio.TwimlResponse();


### PR DESCRIPTION
SessionAttributes, once set, should persist for the duration of the conversation. Passing an empty object in this param clears the sessionAttributes on each user response.